### PR TITLE
feat: add SQLite persistence with SQLAlchemy and DB-backed endpoints

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+sqlalchemy

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,19 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+import os
+
+DATABASE_URL = os.environ.get("DATABASE_URL", "sqlite:///./activities.db")
+
+# For SQLite we need connect_args
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+
+engine = create_engine(DATABASE_URL, connect_args=connect_args)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,37 @@
+from sqlalchemy import Column, Integer, String, Text, ForeignKey, DateTime
+from sqlalchemy.orm import relationship
+from datetime import datetime
+from .db import Base
+
+
+class Activity(Base):
+    __tablename__ = "activities"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String(200), unique=True, nullable=False, index=True)
+    description = Column(Text)
+    schedule = Column(String(200))
+    max_participants = Column(Integer, default=0)
+
+    enrollments = relationship("Enrollment", back_populates="activity", cascade="all, delete-orphan")
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    email = Column(String(200), primary_key=True, index=True)
+    name = Column(String(200), nullable=True)
+
+    enrollments = relationship("Enrollment", back_populates="user", cascade="all, delete-orphan")
+
+
+class Enrollment(Base):
+    __tablename__ = "enrollments"
+
+    id = Column(Integer, primary_key=True, index=True)
+    activity_id = Column(Integer, ForeignKey("activities.id", ondelete="CASCADE"))
+    user_email = Column(String(200), ForeignKey("users.email", ondelete="CASCADE"))
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    activity = relationship("Activity", back_populates="enrollments")
+    user = relationship("User", back_populates="enrollments")


### PR DESCRIPTION
This PR replaces the in-memory activities store with a SQLite database using SQLAlchemy.

What changed:
- Added `src/db.py` (SQLAlchemy engine, session, Base)
- Added `src/models.py` (Activity, User, Enrollment models)
- Updated `src/app.py` to use DB-backed activities and to seed sample activities on startup
- Added `sqlalchemy` to `requirements.txt`

Notes:
- The API contract for `/activities`, `/activities/{activity_name}/signup`, and `/activities/{activity_name}/unregister` is preserved.
- Database file defaults to `./activities.db`. You can override with `DATABASE_URL` environment variable.

Next steps (suggested):
- Add authentication and input validation.
- Add tests for DB-backed endpoints.
- Replace sample seeding with proper migrations if desired.
